### PR TITLE
methods env and env_mut for impl Problem

### DIFF
--- a/cplex-rs/src/lib.rs
+++ b/cplex-rs/src/lib.rs
@@ -148,6 +148,11 @@ impl Problem {
         }
     }
 
+    /// Get a reference to the environment of the problem.
+    pub fn env(&self) -> &Environment {
+        &self.env
+    }
+
     /// Add a variable to the problem.
     ///
     /// The id for the Variable is returned.

--- a/cplex-rs/src/lib.rs
+++ b/cplex-rs/src/lib.rs
@@ -148,6 +148,11 @@ impl Problem {
         }
     }
 
+    /// Get a mutable reference to the environment of the problem.
+    pub fn env_mut(&mut self) -> &mut Environment {
+        &mut self.env
+    }
+
     /// Get a reference to the environment of the problem.
     pub fn env(&self) -> &Environment {
         &self.env


### PR DESCRIPTION
Dear Mr. Biggio,

The research group that I am working with is currently developing EqMap, a tool that performs FPGA technology mapping (https://github.com/cornell-zhang/eqmap/tree/good_lp). EqMap uses e-graph extraction (https://www.csl.cornell.edu/~zhiruz/pdfs/eqmap-iccad2025.pdf) to find an optimal solution to the technology mapping problem, and one of the ways to implement e-graph extraction is through ILP solvers like CPLEX. Currently, we are working on integrating the good_lp ILP library (https://github.com/rust-or/good_lp) into EqMap, and doing so involves implementing the WithTimeLimit trait for struct CPLEXProblem in good_lp (https://github.com/rust-or/good_lp/commit/f4db86ab1622ab1680dd523024882e060aae78ab), which requires adding an "env_mut" method that returns a mutable reference to the Environment member of the cplex-rs Model in order to set the time limit for the CPLEX ILP solver. Thus, we would like to propose these changes to the cplex-rs wrapper. If you are still maintaining this repository, it would be greatly appreciated if you reviewed my proposed code changes!

Sincerely,
Joonho Kim