### PR TITLE
fix: Support Windows

### DIFF
--- a/cplex-rs-sys/build.rs
+++ b/cplex-rs-sys/build.rs
@@ -24,27 +24,34 @@ fn main() {
         println!("cargo:warning=Detected OS: {}", os);
         println!("cargo:warning=Detected arch: {}", arch);
 
-        let os_string = if os == "linux" && arch == "x86_64" {
-            "x86-64_linux"
+        let cplex_include = cplex_installation_path.join("include");
+
+        if os == "linux" && arch == "x86_64" {
+            let lib = cplex_installation_path.join("lib/x86-64_linux/static_pic");
+            println!("cargo:rustc-link-search={}", lib.display());
+            println!("cargo:rustc-link-lib=cplex");
         } else if os == "macos" && arch == "aarch64" {
-            "arm64_osx"
+            let lib = cplex_installation_path.join("lib/arm64_osx/static_pic");
+            println!("cargo:rustc-link-search={}", lib.display());
+            println!("cargo:rustc-link-lib=cplex");
+        } else if os == "windows" && arch == "x86_64" {
+            let lib = cplex_installation_path.join("lib/x64_windows_msvc14/stat_mda");
+            println!("cargo:rustc-link-search={}", lib.display());
+            // CPLEX ships a versioned lib on Windows (e.g. cplex2211.lib).
+            // Discover it at build time rather than hard-coding the version.
+            let lib_name = std::fs::read_dir(&lib)
+                .expect("Could not read CPLEX lib directory")
+                .filter_map(|e| e.ok())
+                .map(|e| e.file_name().to_string_lossy().into_owned())
+                .find(|name| name.starts_with("cplex") && name.ends_with(".lib"))
+                .expect("Could not find cplex*.lib in CPLEX lib directory");
+            let stem = lib_name.trim_end_matches(".lib");
+            println!("cargo:rustc-link-lib={stem}");
         } else {
             panic!("Unsupported OS-arch combination: {}-{}", os, arch);
         };
 
-        let cplex_lib_path = cplex_installation_path.join(format!("lib/{os_string}/static_pic"));
-
-        // Tell cargo to look for shared libraries in the specified directory
-        println!(
-            "cargo:rustc-link-search={}",
-            cplex_lib_path.as_os_str().to_string_lossy()
-        );
-
-        // Tell cargo to tell rustc to link the system cplex
-        // static library.
-        println!("cargo:rustc-link-lib=cplex");
-
-        cplex_installation_path.join("include")
+        cplex_include
     };
 
     // The bindgen::Builder is the main entry point

--- a/cplex-rs/src/parameters/mod.rs
+++ b/cplex-rs/src/parameters/mod.rs
@@ -6,7 +6,7 @@ pub mod read;
 pub mod tolerances;
 
 use std::{
-    ffi::{c_double, c_int, c_long},
+    ffi::{c_double, c_int},
     time::Duration,
 };
 
@@ -40,7 +40,7 @@ pub trait Parameter: private::Parameter {
 #[derive(Copy, Clone, Debug)]
 pub enum ParameterValue {
     Integer(c_int),
-    Long(c_long),
+    Long(i64),
     Double(c_double),
     String(&'static str),
 }


### PR DESCRIPTION
# Add Windows x86_64 support

`cplex-rs` fails to build on Windows x86_64 with two separate errors:

**1. `cplex-rs-sys`: unsupported platform**

`build.rs` only handled `linux/x86_64` and `macos/aarch64`, so Windows builds panic immediately:

```text
thread 'main' panicked at 'Unsupported OS-arch combination: windows-x86_64'
```

**2. `cplex-rs`: `c_long` type mismatch**

`ParameterValue::Long(c_long)` uses `c_long`, which is `i32` on Windows but `i64` on Linux/macOS. This causes type errors when the `Long` variant is constructed or matched anywhere in the codebase:

```text
error[E0308]: mismatched types
  --> src/parameters/barrier/limits.rs:49
   |
   | ParameterValue::Long(self.0 as i64)
   |                      ^^^^^^^^^^^^^ expected `i32`, found `i64`
```

(Errors in `barrier/limits.rs`, `mip/limits.rs`, and `environment.rs`)

## Fixes

**1. Add Windows branch**

We can simply add a `windows/x86_64` branch that:

- Points to `lib/x64_windows_msvc14/stat_mda/`
- Dynamically discovers the versioned lib name (e.g., `cplex2211.lib`) rather than hard-coding it, since the name encodes the CPLEX version

**2. Use `i64` instead of `c_long`**

`CPXLONG` in the CPLEX C API is always `long long` (64-bit), regardless of platform. Using `c_long` is bad on Windows, where `c_long` = `i32`. Replacing with `i64` fixes all type errors and correctly matches the CPLEX API.

## Testing

Built and linked against CPLEX 22.1.1.0 on Windows 10 x86_64 (MSVC toolchain). Existing Linux/macOS behavior has not changed since `c_long = i64` on those platforms, so the only observable difference there is the type annotation.

I've also tested it on my Fedora 44 Niri installation just to be sure, and it worked fine.

## Related issues

Closes https://github.com/cplex-rs/cplex-rs/issues/3